### PR TITLE
add little endian support

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -85,6 +85,12 @@ impl Into<Vec<Box<dyn Finalizer>>> for Finalization {
 	}
 }
 
+#[derive(Debug,PartialEq,Copy,Clone)]
+pub enum Endianness {
+	LITTLE,
+	BIG,
+}
+
 /// A packet `Builder`.
 pub trait Builder<B: Buffer> {
 	/// Create a new packet `Builder` with the given buffer.


### PR DESCRIPTION
it was useful to add in my case. 
I was trying to send packet on macOS and it was failing, even though it worked on linux.

So I've digged into it and found the following:
```- ip_len and ip_off must be in host byte order```

Taken from: https://stackoverflow.com/a/7160206