### PR TITLE
ipv4: do not panic parsing packet where flags are not set

### DIFF
--- a/src/ip/v4/packet.rs
+++ b/src/ip/v4/packet.rs
@@ -215,8 +215,8 @@ impl<B: AsRef<[u8]>> Packet<B> {
 
 	/// Flags of the packet.
 	pub fn flags(&self) -> Flags {
-		Flags::from_bits((&self.buffer.as_ref()[6 ..])
-			.read_u16::<BigEndian>().unwrap() >> 13).unwrap()
+		Flags::from_bits_truncate((&self.buffer.as_ref()[6 ..])
+			.read_u16::<BigEndian>().unwrap() >> 13)
 	}
 
 	/// Offset of the packet.


### PR DESCRIPTION
Currently, on certain packets the flags function will cause a panic 

fixes #23 